### PR TITLE
fix: make sure env vars exist before accessing it

### DIFF
--- a/.changeset/selfish-laws-argue.md
+++ b/.changeset/selfish-laws-argue.md
@@ -1,0 +1,5 @@
+---
+'svelte-clerk': patch
+---
+
+Fix env vars access when prerendering

--- a/packages/svelte-clerk/package.json
+++ b/packages/svelte-clerk/package.json
@@ -58,6 +58,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^3.3.0",
+		"@sveltejs/adapter-static": "^3.0.6",
 		"@sveltejs/kit": "^2.7.2",
 		"@sveltejs/package": "^2.3.6",
 		"@sveltejs/vite-plugin-svelte": "^4.0.0",

--- a/packages/svelte-clerk/src/lib/components/ClerkProvider.svelte
+++ b/packages/svelte-clerk/src/lib/components/ClerkProvider.svelte
@@ -11,8 +11,6 @@
 		type LoadClerkJsScriptOptions
 	} from '@clerk/shared/loadClerkJsScript';
 	import { goto } from '$app/navigation';
-	import { isTruthy } from '@clerk/shared/underscore';
-	import { env as publicEnv } from '$env/dynamic/public';
 
 	const {
 		children,
@@ -43,10 +41,6 @@
 	async function loadClerk() {
 		const opts: LoadClerkJsScriptOptions = {
 			...clerkInitOptions,
-			telemetry: clerkInitOptions.telemetry || {
-				disabled: isTruthy(publicEnv.PUBLIC_CLERK_TELEMETRY_DISABLED),
-				debug: isTruthy(publicEnv.PUBLIC_CLERK_TELEMETRY_DEBUG)
-			},
 			routerPush: (to: string) => goto(to),
 			routerReplace: (to: string) => goto(to, { replaceState: true })
 		};

--- a/packages/svelte-clerk/src/lib/server/constants.ts
+++ b/packages/svelte-clerk/src/lib/server/constants.ts
@@ -9,7 +9,7 @@ function getPublicEnv(name: string, defaultValue = ''): string {
 }
 
 function getPrivateEnv(name: string, defaultValue = ''): string {
-  // @ts-expect-error: Due to the way env vars work in SK, we need to make sure it exists before trying to access it
+	// @ts-expect-error: Due to the way env vars work in SK, we need to make sure it exists before trying to access it
 	return name in envPrivate ? envPrivate[name] : defaultValue;
 }
 

--- a/packages/svelte-clerk/src/lib/server/constants.ts
+++ b/packages/svelte-clerk/src/lib/server/constants.ts
@@ -1,14 +1,26 @@
 import { constants } from '@clerk/backend/internal';
-import { env as privateEnv } from '$env/dynamic/private';
-import { env as publicEnv } from '$env/dynamic/public';
+import * as envPublic from '$env/static/public';
+import * as envPrivate from '$env/static/private';
 import { isTruthy } from '@clerk/shared/underscore';
 
-export const API_VERSION = publicEnv.PUBLIC_CLERK_API_VERSION || 'v1';
-export const SECRET_KEY = privateEnv.CLERK_SECRET_KEY || '';
-export const PUBLISHABLE_KEY = publicEnv.PUBLIC_CLERK_PUBLISHABLE_KEY || '';
-export const API_URL = publicEnv.PUBLIC_CLERK_API_URL;
-export const JWT_KEY = privateEnv.CLERK_JWT_KEY || '';
-export const TELEMETRY_DISABLED = isTruthy(publicEnv.PUBLIC_CLERK_TELEMETRY_DISABLED);
-export const TELEMETRY_DEBUG = isTruthy(publicEnv.PUBLIC_CLERK_TELEMETRY_DEBUG);
+function getPublicEnv(name: string, defaultValue = ''): string {
+	// @ts-expect-error: Due to the way env vars work in SK, we need to make sure it exists before trying to access it
+	return name in envPublic ? envPublic[name] : defaultValue;
+}
+
+function getPrivateEnv(name: string, defaultValue = ''): string {
+  // @ts-expect-error: Due to the way env vars work in SK, we need to make sure it exists before trying to access it
+	return name in envPrivate ? envPrivate[name] : defaultValue;
+}
+
+// Public env variables
+export const API_VERSION = getPublicEnv('PUBLIC_CLERK_API_VERSION', 'v1');
+export const PUBLISHABLE_KEY = getPublicEnv('PUBLIC_CLERK_PUBLISHABLE_KEY');
+export const API_URL = getPublicEnv('PUBLIC_CLERK_API_URL');
+export const TELEMETRY_DISABLED = isTruthy(getPublicEnv('PUBLIC_CLERK_TELEMETRY_DISABLED'));
+export const TELEMETRY_DEBUG = isTruthy(getPublicEnv('PUBLIC_CLERK_TELEMETRY_DEBUG'));
+// Private env variables
+export const SECRET_KEY = getPrivateEnv('CLERK_SECRET_KEY');
+export const JWT_KEY = getPrivateEnv('CLERK_JWT_KEY');
 
 export const { Cookies, Headers } = constants;

--- a/packages/svelte-clerk/svelte.config.js
+++ b/packages/svelte-clerk/svelte.config.js
@@ -1,5 +1,6 @@
 import adapter from '@sveltejs/adapter-auto';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+// import adapter from '@sveltejs/adapter-static';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@sveltejs/adapter-auto':
         specifier: ^3.3.0
         version: 3.3.0(@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.0)(vite@5.4.10))(svelte@5.1.0)(vite@5.4.10))
+      '@sveltejs/adapter-static':
+        specifier: ^3.0.6
+        version: 3.0.6(@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.0)(vite@5.4.10))(svelte@5.1.0)(vite@5.4.10))
       '@sveltejs/kit':
         specifier: ^2.7.2
         version: 2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.0)(vite@5.4.10))(svelte@5.1.0)(vite@5.4.10)
@@ -623,6 +626,11 @@ packages:
 
   '@sveltejs/adapter-auto@3.3.0':
     resolution: {integrity: sha512-EJZqY7eMM+bdbR898Xt9ufawUHLPJu7w3wPr4Cc+T1iIDf3fufVLWg4C71OluIqsdJqv85E4biKuHo3XXIY0PQ==}
+    peerDependencies:
+      '@sveltejs/kit': ^2.0.0
+
+  '@sveltejs/adapter-static@3.0.6':
+    resolution: {integrity: sha512-MGJcesnJWj7FxDcB/GbrdYD3q24Uk0PIL4QIX149ku+hlJuj//nxUbb0HxUTpjkecWfHjVveSUnUaQWnPRXlpg==}
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
 
@@ -2865,6 +2873,10 @@ snapshots:
     dependencies:
       '@sveltejs/kit': 2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.0)(vite@5.4.10))(svelte@5.1.0)(vite@5.4.10)
       import-meta-resolve: 4.1.0
+
+  '@sveltejs/adapter-static@3.0.6(@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.0)(vite@5.4.10))(svelte@5.1.0)(vite@5.4.10))':
+    dependencies:
+      '@sveltejs/kit': 2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.0)(vite@5.4.10))(svelte@5.1.0)(vite@5.4.10)
 
   '@sveltejs/kit@2.7.2(@sveltejs/vite-plugin-svelte@4.0.0(svelte@5.1.0)(vite@5.4.10))(svelte@5.1.0)(vite@5.4.10)':
     dependencies:


### PR DESCRIPTION
This PR adds a logic to make sure an env var exists before trying to access it

Fixes https://github.com/wobsoriano/svelte-clerk/issues/39