### PR TITLE
chore: simplify SSR props

### DIFF
--- a/.changeset/chilly-dingos-mix.md
+++ b/.changeset/chilly-dingos-mix.md
@@ -1,0 +1,5 @@
+---
+'svelte-clerk': patch
+---
+
+Simplify SSR props

--- a/.changeset/chilly-dingos-mix.md
+++ b/.changeset/chilly-dingos-mix.md
@@ -1,5 +1,0 @@
----
-'svelte-clerk': patch
----
-
-Simplify SSR props

--- a/.changeset/stupid-tips-build.md
+++ b/.changeset/stupid-tips-build.md
@@ -1,0 +1,5 @@
+---
+'svelte-clerk': patch
+---
+
+Simplify SSR props

--- a/packages/svelte-clerk/README.md
+++ b/packages/svelte-clerk/README.md
@@ -49,7 +49,7 @@ All Clerk runes and components must be children of the `<ClerkProvider>` compone
 // src/+layout.server.ts
 import { buildClerkProps } from 'svelte-clerk/server';
 
-// To enable Clerk SSR support, pass the `initialState` to the `ClerkProvider` component.
+// To enable Clerk SSR support, add initial state props to the load function
 export const load = ({ locals }) => {
 	return {
 		...buildClerkProps(locals.auth)
@@ -60,22 +60,15 @@ export const load = ({ locals }) => {
 ```svelte
 <script lang="ts">
 	import type { Snippet } from '@svelte';
-	import type { LayoutData } from './$types';
 	import { ClerkProvider } from 'svelte-clerk';
 	import { PUBLIC_CLERK_PUBLISHABLE_KEY } from '$env/static/public';
 
-	const {
-		children,
-		data
-	}: {
-		children: Snippet;
-		data: LayoutData;
-	} = $props();
+	const { children }: { children: Snippet } = $props();
 </script>
 
 <!-- ... -->
 
-<ClerkProvider {...data} publishableKey={PUBLIC_CLERK_PUBLISHABLE_KEY}>
+<ClerkProvider publishableKey={PUBLIC_CLERK_PUBLISHABLE_KEY}>
 	{@render children()}
 </ClerkProvider>
 ```

--- a/packages/svelte-clerk/src/lib/components/ClerkProvider.svelte
+++ b/packages/svelte-clerk/src/lib/components/ClerkProvider.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 	import { untrack } from 'svelte';
-	import type { ClientResource, InitialState, Resources } from '@clerk/types';
+	import type { ClientResource, Resources } from '@clerk/types';
 	import { setClerkContext } from '$lib/context.js';
 	import { deriveState } from '@clerk/shared/deriveState';
 	import type { HeadlessBrowserClerk, BrowserClerk } from '$lib/types.js';
+	import { page } from '$app/stores';
+
 	import {
 		loadClerkJsScript,
 		setClerkJsLoadingErrorPackageName,
@@ -14,11 +16,9 @@
 
 	const {
 		children,
-		initialState,
 		...clerkInitOptions
 	}: LoadClerkJsScriptOptions & {
 		children: Snippet;
-		initialState?: InitialState;
 	} = $props();
 
 	let clerk = $state<HeadlessBrowserClerk | BrowserClerk | null>(null);
@@ -30,7 +30,7 @@
 		organization: undefined
 	});
 
-	let auth = $derived(deriveState(isLoaded, resources, initialState));
+	let auth = $derived(deriveState(isLoaded, resources, $page.data.initialState));
 	let client = $derived(resources.client);
 	let session = $derived(auth.session);
 	let user = $derived(auth.user);

--- a/packages/svelte-clerk/src/lib/server/withClerkHandler.ts
+++ b/packages/svelte-clerk/src/lib/server/withClerkHandler.ts
@@ -6,7 +6,7 @@ import {
 	createClerkRequest,
 	type AuthenticateRequestOptions
 } from '@clerk/backend/internal';
-import { parse } from 'set-cookie-parser'
+import { parse } from 'set-cookie-parser';
 
 export type ClerkSvelteKitMiddlewareOptions = AuthenticateRequestOptions & { debug?: boolean };
 
@@ -43,21 +43,21 @@ export function withClerkHandler(middlewareOptions?: ClerkSvelteKitMiddlewareOpt
 			console.log('[svelte-clerk] ' + JSON.stringify(authObject));
 		}
 
-		type CookieSerializerOptions = Parameters<typeof event.cookies.set>[2]
+		type CookieSerializerOptions = Parameters<typeof event.cookies.set>[2];
 
 		if (requestState.headers) {
-			const setCookie = requestState.headers.get('set-cookie')
+			const setCookie = requestState.headers.get('set-cookie');
 			// We separate cookie setting logic because SvelteKit
 			// does not allow setting cookies with setHeaders.
 			if (setCookie) {
-				const parsedCookies = parse(setCookie)
+				const parsedCookies = parse(setCookie);
 				parsedCookies.forEach((parsedCookie) => {
-					const { name, value, ...options } = parsedCookie
-					event.cookies.set(name, value, options as CookieSerializerOptions & { path: string })
-				})
-				requestState.headers.delete('set-cookie')
+					const { name, value, ...options } = parsedCookie;
+					event.cookies.set(name, value, options as CookieSerializerOptions & { path: string });
+				});
+				requestState.headers.delete('set-cookie');
 			}
-			event.setHeaders(Object.fromEntries(requestState.headers))
+			event.setHeaders(Object.fromEntries(requestState.headers));
 		}
 
 		return resolve(event);

--- a/packages/svelte-clerk/src/routes/+layout.svelte
+++ b/packages/svelte-clerk/src/routes/+layout.svelte
@@ -8,13 +8,11 @@
 		PUBLIC_CLERK_SIGN_IN_URL,
 		PUBLIC_CLERK_SIGN_UP_URL
 	} from '$env/static/public';
-	import type { LayoutData } from './$types';
 
-	let { children, data }: { children: Snippet; data: LayoutData } = $props();
+	let { children }: { children: Snippet } = $props();
 </script>
 
 <ClerkProvider
-	{...data}
 	signInUrl={PUBLIC_CLERK_SIGN_IN_URL}
 	signUpUrl={PUBLIC_CLERK_SIGN_UP_URL}
 	publishableKey={PUBLIC_CLERK_PUBLISHABLE_KEY}


### PR DESCRIPTION
We can get the `initialState` from `$page.data.initialState` so no need to make userland do it by themselves