### PR TITLE
Add default value for PUBLIC_CLERK_API_URL

### DIFF
--- a/packages/svelte-clerk/src/lib/server/constants.ts
+++ b/packages/svelte-clerk/src/lib/server/constants.ts
@@ -16,7 +16,7 @@ function getPrivateEnv(name: string, defaultValue = ''): string {
 // Public env variables
 export const API_VERSION = getPublicEnv('PUBLIC_CLERK_API_VERSION', 'v1');
 export const PUBLISHABLE_KEY = getPublicEnv('PUBLIC_CLERK_PUBLISHABLE_KEY');
-export const API_URL = getPublicEnv('PUBLIC_CLERK_API_URL');
+export const API_URL = getPublicEnv('PUBLIC_CLERK_API_URL', 'https://api.clerk.com');
 export const TELEMETRY_DISABLED = isTruthy(getPublicEnv('PUBLIC_CLERK_TELEMETRY_DISABLED'));
 export const TELEMETRY_DEBUG = isTruthy(getPublicEnv('PUBLIC_CLERK_TELEMETRY_DEBUG'));
 // Private env variables


### PR DESCRIPTION
Without a default value here, not having the URL in your environment variables can leave you with obscure errors like this:
```
TypeError: Invalid URL
    at new URL (node:internal/url:816:29)
    at requestFn (file:///Users/ed/../website/node_modules/@clerk/backend/dist/chunk-CAAZT63Q.mjs:1504:22)
    at UserAPI.request (file:///Users/ed/../website/../@clerk/backend/dist/chunk-CAAZT63Q.mjs:1592:82)
    at UserAPI.getUser (file:///Users/ed/../website/node_modules/@clerk/backend/dist/chunk-CAAZT63Q.mjs:582:17)
  code: 'ERR_INVALID_URL',
  input: 'v1/users/user_xxxxx'
  ```
This is because the default value is set to an empty string, and not `undefined` - I have added a default to the standard Clerk API in the meantime to resolve this issue