### PR TITLE
feat: Add `currentUser` helper function

### DIFF
--- a/.changeset/three-plums-build.md
+++ b/.changeset/three-plums-build.md
@@ -1,0 +1,20 @@
+---
+'svelte-clerk': minor
+---
+
+Add `currentUser` helper function.
+
+Usage:
+
+```ts
+// src/+page.server.ts
+import { buildClerkProps } from 'svelte-clerk/server';
+
+export const load = async ({ locals }) => {
+  const user = await locals.currentUser();
+
+	return {
+		user
+	};
+};
+```

--- a/packages/svelte-clerk/src/lib/env.d.ts
+++ b/packages/svelte-clerk/src/lib/env.d.ts
@@ -1,9 +1,10 @@
-import type { AuthObject } from '@clerk/backend';
+import type { AuthObject, User } from '@clerk/backend';
 
 declare global {
 	namespace App {
 		interface Locals {
 			auth: AuthObject;
+			currentUser: () => Promise<User | null>;
 		}
 	}
 }

--- a/packages/svelte-clerk/src/lib/server/currentUser.ts
+++ b/packages/svelte-clerk/src/lib/server/currentUser.ts
@@ -1,0 +1,13 @@
+import type { AuthObject, User } from "@clerk/backend";
+import { clerkClient } from "./clerkClient.js";
+
+export function createCurrentUser(auth: AuthObject) {
+  return async (): Promise<User | null> => {
+    if (!auth.userId) {
+      return null;
+    }
+
+    const user = await clerkClient.users.getUser(auth.userId);
+    return user;
+  }
+}

--- a/packages/svelte-clerk/src/lib/server/withClerkHandler.ts
+++ b/packages/svelte-clerk/src/lib/server/withClerkHandler.ts
@@ -7,6 +7,7 @@ import {
 	type AuthenticateRequestOptions
 } from '@clerk/backend/internal';
 import { parse } from 'set-cookie-parser';
+import { createCurrentUser } from './currentUser.js';
 
 export type ClerkSvelteKitMiddlewareOptions = AuthenticateRequestOptions & { debug?: boolean };
 
@@ -39,6 +40,7 @@ export function withClerkHandler(middlewareOptions?: ClerkSvelteKitMiddlewareOpt
 
 		const authObject = requestState.toAuth();
 		event.locals.auth = authObject;
+		event.locals.currentUser = createCurrentUser(authObject)
 		if (debug) {
 			console.log('[svelte-clerk] ' + JSON.stringify(authObject));
 		}


### PR DESCRIPTION
This PR adds a `currentUser` helper to the `locals` object that returns the [Backend User](https://clerk.com/docs/references/backend/types/backend-user) object of the currently active user.