### PR TITLE
Add convenience links to the clerk documentation.

### DIFF
--- a/docs/spa/components.md
+++ b/docs/spa/components.md
@@ -2,21 +2,21 @@
 
 The following [Clerk UI components](https://clerk.com/docs/components/overview) are available in Svelte Clerk:
 
-- `<ClerkLoaded>`
-- `<ClerkLoading>`
-- `<Protect>`
-- `<SignedIn>`
-- `<SignedOut>`
-- `<SignIn>`
-- `<SignUp>`
-- `<UserButton>`
-- `<UserProfile>`
-- `<OrganizationList>`
-- `<OrganizationProfile>`
-- `<OrganizationSwitcher>`
-- `<CreateOrganization>`
-- `<GoogleOneTap>`
-- `<Waitlist />`
+- `<ClerkLoaded>` ([clerk docs](https://clerk.com/docs/components/control/clerk-loaded))
+- `<ClerkLoading>` ([clerk docs](https://clerk.com/docs/components/control/clerk-loading))
+- `<Protect>` ([clerk docs](https://clerk.com/docs/components/protect))
+- `<SignedIn>` ([clerk docs](https://clerk.com/docs/components/control/signed-in))
+- `<SignedOut>` ([clerk docs](https://clerk.com/docs/components/control/signed-out))
+- `<SignIn>` ([clerk docs](https://clerk.com/docs/components/authentication/sign-in))
+- `<SignUp>` ([clerk docs](https://clerk.com/docs/components/authentication/sign-up))
+- `<UserButton>` ([clerk docs](https://clerk.com/docs/components/user/user-button))
+- `<UserProfile>` ([clerk docs](https://clerk.com/docs/components/user/user-profile))
+- `<OrganizationList>` ([clerk docs](https://clerk.com/docs/components/organization/organization-list))
+- `<OrganizationProfile>` ([clerk docs](https://clerk.com/docs/components/organization/organization-profile))
+- `<OrganizationSwitcher>` ([clerk docs](https://clerk.com/docs/components/organization/organization-switcher))
+- `<CreateOrganization>` ([clerk docs](https://clerk.com/docs/components/organization/create-organization))
+- `<GoogleOneTap>` ([clerk docs](https://clerk.com/docs/components/authentication/google-one-tap))
+- `<Waitlist />` ([clerk docs](https://clerk.com/docs/components/waitlist))
 
 The main difference is that the Svelte components use [`Snippets`](https://svelte.dev/docs/svelte/snippet) to render their content.
 


### PR DESCRIPTION
Do you accept doc-only PRs?

It made it easier for me to go directly to the relevant Clerk documentation, so I added them to the list.