### PR TITLE
Fix bug in setting cookies from the handshake when session is being refreshed in Clerk production environments

### DIFF
--- a/src/lib/server/withClerkHandler.ts
+++ b/src/lib/server/withClerkHandler.ts
@@ -69,7 +69,8 @@ function decorateHeaders(event: RequestEvent, headers: Headers) {
 	// We separate cookie setting logic because SvelteKit
 	// does not allow setting cookies with setHeaders.
 	if (setCookie) {
-		const parsedCookies = parse(setCookie);
+		const splitCookies = splitCookiesString(setCookie);
+		const parsedCookies = parse(splitCookies);
 		parsedCookies.forEach((parsedCookie) => {
 			const { name, value, ...options } = parsedCookie;
 			event.cookies.set(name, value, options as CookieSerializerOptions & { path: string });

--- a/src/lib/server/withClerkHandler.ts
+++ b/src/lib/server/withClerkHandler.ts
@@ -6,7 +6,7 @@ import {
 	createClerkRequest,
 	type AuthenticateRequestOptions,
 } from '@clerk/backend/internal';
-import { parse } from 'set-cookie-parser';
+import { parse, splitCookiesString } from 'set-cookie-parser';
 import { createCurrentUser } from './currentUser.js';
 import type { SignedInAuthObject, SignedOutAuthObject } from '@clerk/backend/internal';
 import { handleNetlifyCacheInDevInstance } from '@clerk/shared/netlifyCacheHandler';


### PR DESCRIPTION
Only a single `set-cookie` header is being read when just using `parse()`, hence, the session cookie is not being set. In order to retrieve all the individual `set-cookie` headers, we should run it through `splitCookiesString()` first.