### PR TITLE
Import PK from the public env

### DIFF
--- a/docs/spa/quickstart.md
+++ b/docs/spa/quickstart.md
@@ -31,7 +31,7 @@ All Clerk runes and components must be children of the `<ClerkProvider>` compone
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 	import { ClerkProvider } from 'svelte-clerk/client';
-	import { PUBLIC_CLERK_PUBLISHABLE_KEY } from '$env/static/private';
+	import { PUBLIC_CLERK_PUBLISHABLE_KEY } from '$env/static/public';
 
 	const { children }: { children: Snippet } = $props();
 </script>


### PR DESCRIPTION
Hey!

First of all, thank you for this lib. Trying it out (and Clerk in general) for the first time now.

I noticed one tiny detail in the example code:
Public env vars need to be imported via `$env/static/public` instead of `$env/static/private`.

Cheers,
Dominic

P.S.: First PR here, hope it's ok like that.