### PR TITLE
Remove SvelteKit reference in client exports

### DIFF
--- a/.changeset/early-dancers-rhyme.md
+++ b/.changeset/early-dancers-rhyme.md
@@ -1,0 +1,5 @@
+---
+'svelte-clerk': minor
+---
+
+Remove SvelteKit imports in client export

--- a/src/lib/ClerkProvider.svelte
+++ b/src/lib/ClerkProvider.svelte
@@ -3,7 +3,8 @@
 	import { mergeWithPublicEnvVariables } from '$lib/utils/mergeWithPublicEnvVariables.js';
 	import type { ClerkProviderProps } from '$lib/types.js';
 	import { page } from '$app/state';
-	import type { LoadClerkJsScriptOptions } from '@clerk/shared';
+	import type { LoadClerkJsScriptOptions } from '@clerk/shared/loadClerkJsScript';
+	import { goto } from '$app/navigation';
 
 	const {
 		children,
@@ -14,7 +15,9 @@
 
 	const mergedProps = $derived({
 		...props,
-		...mergeWithPublicEnvVariables(props)
+		...mergeWithPublicEnvVariables(props),
+		routerPush: (to: string) => goto(to),
+		routerReplace: (to: string) => goto(to, { replaceState: true }),
 	} as LoadClerkJsScriptOptions);
 </script>
 

--- a/src/lib/client/ClerkProvider.svelte
+++ b/src/lib/client/ClerkProvider.svelte
@@ -8,9 +8,7 @@
 	import {
 		loadClerkJsScript,
 		setClerkJsLoadingErrorPackageName,
-		type LoadClerkJsScriptOptions
 	} from '@clerk/shared/loadClerkJsScript';
-	import { goto } from '$app/navigation';
 	import { watch } from './utils.svelte';
 
 	const {
@@ -39,20 +37,14 @@
 	setClerkJsLoadingErrorPackageName('svelte-clerk');
 
 	async function loadClerk() {
-		const opts = {
-			routerPush: (to: string) => goto(to),
-			routerReplace: (to: string) => goto(to, { replaceState: true }),
-			...props
-		};
-
-		await loadClerkJsScript(opts as LoadClerkJsScriptOptions);
+		await loadClerkJsScript(props);
 
 		if (!window.Clerk) {
 			throw new Error('Clerk script failed to load');
 		}
 
 		clerk = window.Clerk;
-		await clerk.load(opts);
+		await clerk.load(props);
 
 		isLoaded = true;
 

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -54,14 +54,14 @@ export interface ClerkContext {
 }
 
 export const useClerkContext = (): ClerkContext => {
-	const client = getContext(_contextKey);
+	const client = getContext<ClerkContext>(_contextKey);
 	if (!client) {
 		throw new Error(
 			'No Clerk data was found in Svelte context. Did you forget to wrap your component with ClerkProvider?'
 		);
 	}
 
-	return client as ClerkContext;
+	return client;
 };
 
 export const setClerkContext = (context: ClerkContext): void => {


### PR DESCRIPTION
This PR allows Svelte Clerk components to be used outside of SvelteKit