### PR TITLE
fix: TypeScript 6.0 compatibility — remove `as` assertions from template expressions

### DIFF
--- a/src/lib/ClerkProvider.svelte
+++ b/src/lib/ClerkProvider.svelte
@@ -36,9 +36,9 @@
 				goto(to, { replaceState: true });
 			}
 		}
-	} as Omit<ClerkProviderProps, 'children'>);
+	});
 </script>
 
-<ClerkProvider initialState={page?.data?.initialState} {...mergedProps as any}>
+<ClerkProvider initialState={page?.data?.initialState} {...mergedProps}>
 	{@render children?.()}
 </ClerkProvider>

--- a/src/lib/client/control/ClerkLoaded.svelte
+++ b/src/lib/client/control/ClerkLoaded.svelte
@@ -6,8 +6,12 @@
 	const { children }: { children: Snippet<[LoadedClerk]> } = $props();
 
 	const ctx = useClerkContext();
+
+	function getLoadedClerk(): LoadedClerk {
+		return ctx.clerk as LoadedClerk;
+	}
 </script>
 
 {#if ctx.isLoaded}
-	{@render children(ctx.clerk as LoadedClerk)}
+	{@render children(getLoadedClerk())}
 {/if}

--- a/src/lib/client/interactive/APIKeys.svelte
+++ b/src/lib/client/interactive/APIKeys.svelte
@@ -5,6 +5,11 @@
 	import { fromAction } from 'svelte/attachments';
 
 	const props: APIKeysProps = $props();
+
+	// Access internal Clerk API not exposed in LoadedClerk type
+	function getUpdateProps(clerk: { __internal_updateProps?: unknown }) {
+		return clerk.__internal_updateProps;
+	}
 </script>
 
 <ClerkLoaded>
@@ -13,7 +18,7 @@
 			{@attach fromAction(clerkHostRenderer, () => ({
 				mount: clerk.mountAPIKeys,
 				unmount: clerk.unmountAPIKeys,
-				updateProps: (clerk as any).__internal_updateProps,
+				updateProps: getUpdateProps(clerk),
 				props: $state.snapshot(props)
 			}))}
 		></div>

--- a/src/lib/client/interactive/CreateOrganization.svelte
+++ b/src/lib/client/interactive/CreateOrganization.svelte
@@ -5,6 +5,11 @@
 	import { fromAction } from 'svelte/attachments';
 
 	const props: CreateOrganizationProps = $props();
+
+	// Access internal Clerk API not exposed in LoadedClerk type
+	function getUpdateProps(clerk: { __internal_updateProps?: unknown }) {
+		return clerk.__internal_updateProps;
+	}
 </script>
 
 <ClerkLoaded>
@@ -13,7 +18,7 @@
 			{@attach fromAction(clerkHostRenderer, () => ({
 				mount: clerk.mountCreateOrganization,
 				unmount: clerk.unmountCreateOrganization,
-				updateProps: (clerk as any).__internal_updateProps,
+				updateProps: getUpdateProps(clerk),
 				props: $state.snapshot(props)
 			}))}
 		></div>

--- a/src/lib/client/interactive/OrganizationList.svelte
+++ b/src/lib/client/interactive/OrganizationList.svelte
@@ -5,6 +5,11 @@
 	import { fromAction } from 'svelte/attachments';
 
 	const props: OrganizationListProps = $props();
+
+	// Access internal Clerk API not exposed in LoadedClerk type
+	function getUpdateProps(clerk: { __internal_updateProps?: unknown }) {
+		return clerk.__internal_updateProps;
+	}
 </script>
 
 <ClerkLoaded>
@@ -13,7 +18,7 @@
 			{@attach fromAction(clerkHostRenderer, () => ({
 				mount: clerk.mountOrganizationList,
 				unmount: clerk.unmountOrganizationList,
-				updateProps: (clerk as any).__internal_updateProps,
+				updateProps: getUpdateProps(clerk),
 				props: $state.snapshot(props)
 			}))}
 		></div>

--- a/src/lib/client/interactive/OrganizationProfile.svelte
+++ b/src/lib/client/interactive/OrganizationProfile.svelte
@@ -5,6 +5,11 @@
 	import { fromAction } from 'svelte/attachments';
 
 	const props: OrganizationProfileProps = $props();
+
+	// Access internal Clerk API not exposed in LoadedClerk type
+	function getUpdateProps(clerk: { __internal_updateProps?: unknown }) {
+		return clerk.__internal_updateProps;
+	}
 </script>
 
 <ClerkLoaded>
@@ -13,7 +18,7 @@
 			{@attach fromAction(clerkHostRenderer, () => ({
 				mount: clerk.mountOrganizationProfile,
 				unmount: clerk.unmountOrganizationProfile,
-				updateProps: (clerk as any).__internal_updateProps,
+				updateProps: getUpdateProps(clerk),
 				props: $state.snapshot(props)
 			}))}
 		></div>

--- a/src/lib/client/interactive/OrganizationSwitcher.svelte
+++ b/src/lib/client/interactive/OrganizationSwitcher.svelte
@@ -5,6 +5,11 @@
 	import { fromAction } from 'svelte/attachments';
 
 	const props: OrganizationSwitcherProps = $props();
+
+	// Access internal Clerk API not exposed in LoadedClerk type
+	function getUpdateProps(clerk: { __internal_updateProps?: unknown }) {
+		return clerk.__internal_updateProps;
+	}
 </script>
 
 <ClerkLoaded>
@@ -13,7 +18,7 @@
 			{@attach fromAction(clerkHostRenderer, () => ({
 				mount: clerk.mountOrganizationSwitcher,
 				unmount: clerk.unmountOrganizationSwitcher,
-				updateProps: (clerk as any).__internal_updateProps,
+				updateProps: getUpdateProps(clerk),
 				props: $state.snapshot(props)
 			}))}
 		></div>

--- a/src/lib/client/interactive/PricingTable.svelte
+++ b/src/lib/client/interactive/PricingTable.svelte
@@ -5,6 +5,11 @@
 	import { fromAction } from 'svelte/attachments';
 
 	const props: PricingTableProps = $props();
+
+	// Access internal Clerk API not exposed in LoadedClerk type
+	function getUpdateProps(clerk: { __internal_updateProps?: unknown }) {
+		return clerk.__internal_updateProps;
+	}
 </script>
 
 <ClerkLoaded>
@@ -13,7 +18,7 @@
 			{@attach fromAction(clerkHostRenderer, () => ({
 				mount: clerk.mountPricingTable,
 				unmount: clerk.unmountPricingTable,
-				updateProps: (clerk as any).__internal_updateProps,
+				updateProps: getUpdateProps(clerk),
 				props: $state.snapshot(props)
 			}))}
 		></div>

--- a/src/lib/client/interactive/SignIn.svelte
+++ b/src/lib/client/interactive/SignIn.svelte
@@ -5,6 +5,11 @@
 	import { fromAction } from 'svelte/attachments';
 
 	const props: SignInProps = $props();
+
+	// Access internal Clerk API not exposed in LoadedClerk type
+	function getUpdateProps(clerk: { __internal_updateProps?: unknown }) {
+		return clerk.__internal_updateProps;
+	}
 </script>
 
 <ClerkLoaded>
@@ -13,7 +18,7 @@
 			{@attach fromAction(clerkHostRenderer, () => ({
 				mount: clerk.mountSignIn,
 				unmount: clerk.unmountSignIn,
-				updateProps: (clerk as any).__internal_updateProps,
+				updateProps: getUpdateProps(clerk),
 				props: $state.snapshot(props)
 			}))}
 		></div>

--- a/src/lib/client/interactive/SignUp.svelte
+++ b/src/lib/client/interactive/SignUp.svelte
@@ -5,6 +5,11 @@
 	import { fromAction } from 'svelte/attachments';
 
 	const props: SignUpProps = $props();
+
+	// Access internal Clerk API not exposed in LoadedClerk type
+	function getUpdateProps(clerk: { __internal_updateProps?: unknown }) {
+		return clerk.__internal_updateProps;
+	}
 </script>
 
 <ClerkLoaded>
@@ -13,7 +18,7 @@
 			{@attach fromAction(clerkHostRenderer, () => ({
 				mount: clerk.mountSignUp,
 				unmount: clerk.unmountSignUp,
-				updateProps: (clerk as any).__internal_updateProps,
+				updateProps: getUpdateProps(clerk),
 				props: $state.snapshot(props)
 			}))}
 		></div>

--- a/src/lib/client/interactive/UserAvatar.svelte
+++ b/src/lib/client/interactive/UserAvatar.svelte
@@ -5,6 +5,11 @@
 	import { fromAction } from 'svelte/attachments';
 
 	const props: UserAvatarProps = $props();
+
+	// Access internal Clerk API not exposed in LoadedClerk type
+	function getUpdateProps(clerk: { __internal_updateProps?: unknown }) {
+		return clerk.__internal_updateProps;
+	}
 </script>
 
 <ClerkLoaded>
@@ -13,7 +18,7 @@
 			{@attach fromAction(clerkHostRenderer, () => ({
 				mount: clerk.mountUserAvatar,
 				unmount: clerk.unmountUserAvatar,
-				updateProps: (clerk as any).__internal_updateProps,
+				updateProps: getUpdateProps(clerk),
 				props: $state.snapshot(props)
 			}))}
 		></div>

--- a/src/lib/client/interactive/UserProfile.svelte
+++ b/src/lib/client/interactive/UserProfile.svelte
@@ -5,6 +5,11 @@
 	import { fromAction } from 'svelte/attachments';
 
 	const props: UserProfileProps = $props();
+
+	// Access internal Clerk API not exposed in LoadedClerk type
+	function getUpdateProps(clerk: { __internal_updateProps?: unknown }) {
+		return clerk.__internal_updateProps;
+	}
 </script>
 
 <ClerkLoaded>
@@ -13,7 +18,7 @@
 			{@attach fromAction(clerkHostRenderer, () => ({
 				mount: clerk.mountUserProfile,
 				unmount: clerk.unmountUserProfile,
-				updateProps: (clerk as any).__internal_updateProps,
+				updateProps: getUpdateProps(clerk),
 				props: $state.snapshot(props)
 			}))}
 		></div>

--- a/src/lib/client/interactive/Waitlist.svelte
+++ b/src/lib/client/interactive/Waitlist.svelte
@@ -5,6 +5,11 @@
 	import { fromAction } from 'svelte/attachments';
 
 	const props: WaitlistProps = $props();
+
+	// Access internal Clerk API not exposed in LoadedClerk type
+	function getUpdateProps(clerk: { __internal_updateProps?: unknown }) {
+		return clerk.__internal_updateProps;
+	}
 </script>
 
 <ClerkLoaded>
@@ -13,7 +18,7 @@
 			{@attach fromAction(clerkHostRenderer, () => ({
 				mount: clerk.mountWaitlist,
 				unmount: clerk.unmountWaitlist,
-				updateProps: (clerk as any).__internal_updateProps,
+				updateProps: getUpdateProps(clerk),
 				props: $state.snapshot(props)
 			}))}
 		></div>


### PR DESCRIPTION
## Problem

Svelte's template parser does not support TypeScript `as` type assertions in template expressions (`{...}`, `{@render}`, `{@attach}`). These cause `js_parse_error` at compile time, particularly with TypeScript 6.0+ where `as` assertions are deprecated.

Example error:
```
[plugin:vite-plugin-svelte:compile] /node_modules/svelte-clerk/dist/client/interactive/SignIn.svelte:16:24
Unexpected token
updateProps: (clerk as any).__internal_updateProps,
                         ^
```

## Changes

**13 files changed:**

- **11 interactive components** (SignIn, SignUp, APIKeys, etc.): Moved `(clerk as any).__internal_updateProps` from template `{@attach}` expressions to a typed `getUpdateProps()` helper function in the `<script>` block
- **ClerkLoaded.svelte**: Moved `ctx.clerk as LoadedClerk` from `{@render}` expression to a `getLoadedClerk()` helper in the script block
- **ClerkProvider.svelte**: Removed unnecessary `as Omit<...>` and `as any` casts from the template spread

All remaining `as` assertions are in `<script>` blocks, where the Svelte compiler delegates to TypeScript directly (no parse errors).

## Context

- [svelte#15425 - JS Parse Error for valid TypeScript](https://github.com/sveltejs/svelte/issues/15425)
- TypeScript 6.0 deprecates `as` assertions, making this increasingly important for downstream consumers